### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/deepmerge.js
+++ b/lib/deepmerge.js
@@ -9,11 +9,15 @@ const merge = (...sources) => {
   }
 
   // in case of only one valid object in the arguments
-  if (onlyObjects.length === 1 && onlyObjects[0] != constructor.prototype) {
+  if (onlyObjects.length === 1) {
     return onlyObjects[0];
   }
 
-  const [target, ...rest] = onlyObjects;
+  let [target, ...rest] = onlyObjects;
+
+  if (target === Object.prototype) {
+    target = {};
+  }
 
   rest.forEach(object => {
     for (const key in object) {

--- a/lib/deepmerge.js
+++ b/lib/deepmerge.js
@@ -9,7 +9,7 @@ const merge = (...sources) => {
   }
 
   // in case of only one valid object in the arguments
-  if (onlyObjects.length === 1) {
+  if (onlyObjects.length === 1 && onlyObjects[0] != constructor.prototype) {
     return onlyObjects[0];
   }
 

--- a/lib/deepmerge.spec.js
+++ b/lib/deepmerge.spec.js
@@ -187,4 +187,10 @@ describe('Merge tests', () => {
     const obj1 = { a: { c: 4 } };
     expect(merge(obj1, new Date())).toEqual(obj1);
   });
+
+  it('Should pass', () => {
+    const obj1 = { polluted: true };
+    expect(merge(Object.prototype, obj1)).toEqual(obj1);
+    expect({}.polluted).toBe(undefined);
+  });
 });


### PR DESCRIPTION
### :bar_chart: Metadata *

`deep-merge-js` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-deep-merge-js

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const merge = require('deep-merge-js')

console.log(`Before: ${{}.polluted}`)
merge(constructor.prototype, {polluted: true})
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i deep-merge-js # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105277546-9f0e4a00-5bc9-11eb-8465-46943ee6b03a.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
